### PR TITLE
chore(rebrand): metadata & NOTICE (no code changes)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# NOTICE
+
+This repository is an **independent fork** of upstream Uniswap code and is **not affiliated with or endorsed by Uniswap**.
+
+- Upstream source: git@github.com:Uniswap/router-sdk.git
+- Copyrights and licenses remain with their respective owners.
+- See `LICENSE` for full licensing terms of this repository. Some upstream components may be under different licenses; consult upstream for details.
+
+This fork primarily changes branding and build/release metadata at this stage. Functional changes (if any) will be documented in release notes and pull requests.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Independent fork** — not affiliated with Uniswap. See NOTICE.md.
+
 # @uniswap/router-sdk - Now at `Uniswap/sdks`
 
 All versions after 1.9.0 of this SDK can be found in the [SDK monorepo](https://github.com/Uniswap/sdks/tree/main/sdks/router-sdk)! Please file all future issues, PR’s, and discussions there.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/router-sdk",
   "version": "1.9.0",
-  "description": "An sdk for routing swaps using Uniswap v2 and Uniswap v3.",
+  "description": "Primea fork — independent fork of upstream Uniswap repo",
   "publishConfig": {
     "access": "public"
   },
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Uniswap/router-sdk.git"
+    "url": "git+ssh://git@github.com/primeanetwork/router-sdk.git"
   },
   "keywords": [
     "uniswap",
@@ -41,5 +41,9 @@
     "printWidth": 120,
     "semi": false,
     "singleQuote": true
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/primeanetwork/router-sdk/issues"
+  },
+  "homepage": "https://github.com/primeanetwork/router-sdk#readme"
 }


### PR DESCRIPTION
Adds `NOTICE.md`, injects an in-repo banner in `README.md`, and updates `package.json` metadata fields to point to `primeanetwork/router-sdk`. **No product code changes.**